### PR TITLE
refactor: rename plugin to kubectl-print-env

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,17 +2,17 @@ before:
   hooks:
     - go mod tidy
 builds:
-  - id: kubectl-env
-    main: ./cmd/kubectl-env
-    binary: kubectl-env
+  - id: kubectl-print-env
+    main: ./cmd/kubectl-print-env
+    binary: kubectl-print-env
     goos:
       - darwin
       - linux
       - windows
     ldflags:
       - -w -s
-      - -X kubectl-env/internal/version.version={{ trimprefix .Version "v" }}
-      - -X kubectl-env/internal/version.gitCommit={{ .Commit }}
+      - -X kubectl-print-env/internal/version.version={{ trimprefix .Version "v" }}
+      - -X kubectl-print-env/internal/version.gitCommit={{ .Commit }}
     env:
       - CGO_ENABLE=0
 archives:
@@ -25,10 +25,10 @@ archives:
 checksum:
   name_template: checksums.txt
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  name_template: "{{ .Version }}-next"
 nfpms:
-  - homepage: https://github.com/pedrobarco/kubectl-env
-    description: kubectl-env is a kubectl plugin that builds config files from k8s environments
+  - homepage: https://github.com/pedrobarco/kubectl-print-env
+    description: kubectl-print-env is a kubectl plugin that builds config files from k8s environments
     maintainer: Pedro Barco <pedro.barco@tecnico.ulisboa.pt>
     license: MIT
     formats:
@@ -42,10 +42,10 @@ changelog:
       - '^docs:'
       - '^test:'
 krews:
-  - name: env
+  - name: print-env
     index:
       owner: pedrobarco
-      name: kubectl-env
+      name: kubectl-print-env
     commit_author:
       name: Pedro Barco
       email: pedro.barco@tecnico.ulisboa.pt

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BINDIR      := $(CURDIR)/bin
 INSTALL_PATH ?= /usr/local/bin
-BINNAME     ?= kubectl-env
+BINNAME     ?= kubectl-print-env
 
 GOBIN         = $(shell go env GOBIN)
 ifeq ($(GOBIN),)
@@ -35,9 +35,9 @@ ifdef VERSION
 endif
 BINARY_VERSION ?= $(GIT_TAG)
 
-LDFLAGS += -X kubectl-env/internal/version.version=$(BINARY_VERSION)
-LDFLAGS += -X kubectl-env/internal/version.metadata=$(VERSION_METADATA)
-LDFLAGS += -X kubectl-env/internal/version.gitCommit=$(GIT_COMMIT)
+LDFLAGS += -X kubectl-print-env/internal/version.version=$(BINARY_VERSION)
+LDFLAGS += -X kubectl-print-env/internal/version.metadata=$(VERSION_METADATA)
+LDFLAGS += -X kubectl-print-env/internal/version.gitCommit=$(GIT_COMMIT)
 LDFLAGS += $(EXT_LDFLAGS)
 
 .PHONY: all
@@ -50,7 +50,7 @@ all: build
 build: $(BINDIR)/$(BINNAME)
 
 $(BINDIR)/$(BINNAME): $(SRC)
-	GO111MODULE=on go build $(GOFLAGS) -trimpath -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o '$(BINDIR)/$(BINNAME)' ./cmd/kubectl-env
+	GO111MODULE=on go build $(GOFLAGS) -trimpath -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o '$(BINDIR)/$(BINNAME)' ./cmd/kubectl-print-env
 
 # ------------------------------------------------------------------------------
 #  install

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# kubectl-env
+# kubectl-print-env
 
 A kubectl plugin for building config files from k8s environments
 
-With `kubectl-env`, it is possible to create a config file from kubernetes
+With `kubectl-print-env`, it is possible to create a config file from kubernetes
 resources. This plugin prints configs by parsing environment information about
 the specified resources. You can select the output format using the `--output`
 flag.
@@ -10,18 +10,18 @@ flag.
 
 ## Installation
 
-`kubectl-env` can be installed using [Krew](https://krew.sigs.k8s.io):
+`kubectl-print-env` can be installed using [Krew](https://krew.sigs.k8s.io):
 
 ```bash
 $ kubectl krew install env
 ```
 
-or by downloading the binary from the [releases](https://github.com/pedrobarco/kubectl-env/releases) page.
+or by downloading the binary from the [releases](https://github.com/pedrobarco/kubectl-print-env/releases) page.
 
-Alternatively, `kubectl-env` can be installed by running
+Alternatively, `kubectl-print-env` can be installed by running
 
 ```bash
-$ go install github.com/pedrobarco/kubectl-env
+$ go install github.com/pedrobarco/kubectl-print-env
 ```
 
 or by cloning this repository and running:
@@ -34,20 +34,20 @@ $ make build && sudo make install
 ## Usage
 
 ```
-kubectl env [(-o|--output=)dotenv|json|toml|yaml] (TYPE[.VERSION][.GROUP] [NAME] | TYPE[.VERSION][.GROUP]/NAME) [flags]
+kubectl print-env [(-o|--output=)dotenv|json|toml|yaml] (TYPE[.VERSION][.GROUP] [NAME] | TYPE[.VERSION][.GROUP]/NAME) [flags]
 
 Examples:
   # Build a dotenv config file from a pod
-  kubectl env pods my-pod
+  kubectl print-env pods my-pod
 
   # Build a JSON config file from a deployment, in the "v1" version of the "apps" API group
-  kubectl env deployments.v1.apps my-deployment -o json
+  kubectl print-env deployments.v1.apps my-deployment -o json
 
   # Build a YAML config file from a configmap
-  kubectl env cm/my-configmap -o yaml
+  kubectl print-env cm/my-configmap -o yaml
 
   # Build a TOML config file from a secret, decoding secret values
-  kubectl env secret my-secret -o toml
+  kubectl print-env secret my-secret -o toml
 ```
 
 ## Specification
@@ -65,4 +65,4 @@ This plugin supports the following resource types:
 - [ ] Service
 - [ ] Ingress
 
-> NOTE: When running `kubectl-env`, only resources of this type will be checked
+> NOTE: When running `kubectl-print-env`, only resources of this type will be checked

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ flag.
 `kubectl-print-env` can be installed using [Krew](https://krew.sigs.k8s.io):
 
 ```bash
-$ kubectl krew install env
+$ kubectl krew install print-env
 ```
 
 or by downloading the binary from the [releases](https://github.com/pedrobarco/kubectl-print-env/releases) page.

--- a/cmd/kubectl-print-env/main.go
+++ b/cmd/kubectl-print-env/main.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"github.com/pedrobarco/kubectl-env/cmd/kubectl-env/env"
+	"github.com/pedrobarco/kubectl-print-env/cmd/kubectl-print-env/printenv"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 func main() {
-	c := env.NewCmdEnv()
+	c := printenv.NewCmdEnv()
 	_ = c.Execute()
 }

--- a/cmd/kubectl-print-env/printenv/printenv.go
+++ b/cmd/kubectl-print-env/printenv/printenv.go
@@ -1,12 +1,12 @@
-package env
+package printenv
 
 import (
 	"fmt"
 	"os"
 	"strings"
 
-	"github.com/pedrobarco/kubectl-env/pkg/parser"
-	"github.com/pedrobarco/kubectl-env/pkg/printers"
+	"github.com/pedrobarco/kubectl-print-env/pkg/parser"
+	"github.com/pedrobarco/kubectl-print-env/pkg/printers"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -15,7 +15,7 @@ import (
 	"k8s.io/kubectl/pkg/util/templates"
 )
 
-type EnvOptions struct {
+type PrintEnvOptions struct {
 	formatFlags *FormatFlags
 	configFlags *genericclioptions.ConfigFlags
 
@@ -36,16 +36,16 @@ var (
 
 	envExample = templates.Examples(i18n.T(`
 		# Build a dotenv config file from a pod
-		kubectl env pods my-pod
+		kubectl print-env pods my-pod
 
 		# Build a JSON config file from a deployment, in the "v1" version of the "apps" API group
-		kubectl env deployments.v1.apps my-deployment -o json
+		kubectl print-env deployments.v1.apps my-deployment -o json
 
 		# Build a YAML config file from a configmap
-		kubectl env cm/my-configmap -o yaml
+		kubectl print-env cm/my-configmap -o yaml
 
 		# Build a TOML config file from a secret, decoding secret values
-		kubectl env secret my-secret -o toml`))
+		kubectl print-env secret my-secret -o toml`))
 )
 
 func CheckErr(err error) {
@@ -56,11 +56,11 @@ func CheckErr(err error) {
 }
 
 func NewCmdEnv() *cobra.Command {
-	o := &EnvOptions{formatFlags: &FormatFlags{Format: printers.DotEnv}}
+	o := &PrintEnvOptions{formatFlags: &FormatFlags{Format: printers.DotEnv}}
 	f := genericclioptions.NewConfigFlags(true)
 
 	cmd := &cobra.Command{
-		Use:          fmt.Sprintf("kubectl env [(-o|--output=)%s] (TYPE[.VERSION][.GROUP] [NAME] | TYPE[.VERSION][.GROUP]/NAME)", strings.Join(o.formatFlags.AllowedFormats(), "|")),
+		Use:          fmt.Sprintf("kubectl print-env [(-o|--output=)%s] (TYPE[.VERSION][.GROUP] [NAME] | TYPE[.VERSION][.GROUP]/NAME)", strings.Join(o.formatFlags.AllowedFormats(), "|")),
 		Short:        i18n.T("Build config files from k8s environments"),
 		Long:         envLong,
 		Example:      envExample,
@@ -79,7 +79,7 @@ func NewCmdEnv() *cobra.Command {
 	return cmd
 }
 
-func (o *EnvOptions) Complete(f *genericclioptions.ConfigFlags, cmd *cobra.Command, args []string) error {
+func (o *PrintEnvOptions) Complete(f *genericclioptions.ConfigFlags, cmd *cobra.Command, args []string) error {
 	ns, _, err := f.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
 		return err
@@ -98,11 +98,11 @@ func (o *EnvOptions) Complete(f *genericclioptions.ConfigFlags, cmd *cobra.Comma
 	return nil
 }
 
-func (o *EnvOptions) Validate() error {
+func (o *PrintEnvOptions) Validate() error {
 	return nil
 }
 
-func (o *EnvOptions) Run() error {
+func (o *PrintEnvOptions) Run() error {
 	result := o.builder.Unstructured().
 		NamespaceParam(o.namespace).
 		DefaultNamespace().

--- a/cmd/kubectl-print-env/printenv/printenv_flags.go
+++ b/cmd/kubectl-print-env/printenv/printenv_flags.go
@@ -1,11 +1,11 @@
-package env
+package printenv
 
 import (
 	"fmt"
 	"sort"
 	"strings"
 
-	"github.com/pedrobarco/kubectl-env/pkg/printers"
+	"github.com/pedrobarco/kubectl-print-env/pkg/printers"
 )
 
 type FormatFlags struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pedrobarco/kubectl-env
+module github.com/pedrobarco/kubectl-print-env
 
 go 1.17
 


### PR DESCRIPTION
This PR renames the plugin to `kubectl-print-env` as request by https://github.com/kubernetes-sigs/krew-index/pull/2121